### PR TITLE
fix err no pca

### DIFF
--- a/pca9685_for_pico/servo.py
+++ b/pca9685_for_pico/servo.py
@@ -2,7 +2,7 @@
 # Kevin McAleer
 # March 2021
 
-from pca import PCA9685
+from pca9685 import PCA9685
 import math
 
 


### PR DESCRIPTION
when importing PCA9685 in line 5 you get an error because pca.py doesn't exist. Fix is to change pca to pca9685